### PR TITLE
Fix serialization of reservation timestamps in API responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,15 @@ def execute_query(query, params=None):
             print(f"Error en la base de datos: {e}")
             raise HTTPException(status_code=500, detail="Error en la base de datos")
 
+
+def serialize_reservation(row):
+    reservation = row._asdict()
+    for key in ["in_time", "out_time"]:
+        value = reservation.get(key)
+        if isinstance(value, datetime):
+            reservation[key] = value.strftime("%Y-%m-%d")
+    return reservation
+
 # --- Endpoints ---
 
 @app.get("/")
@@ -158,7 +167,7 @@ async def get_active_reservations(user_id: int):
     """
     reservations = execute_query(query, {"user_id": user_id, "now": now}).fetchall()
     
-    active_reservations = [row._asdict() for row in reservations]
+    active_reservations = [serialize_reservation(row) for row in reservations]
     
     return JSONResponse(content={"reservations": active_reservations}, status_code=200)
 
@@ -184,7 +193,7 @@ async def get_past_reservations(user_id: int):
     """
     reservations = execute_query(query, {"user_id": user_id, "now": now}).fetchall()
     
-    past_reservations = [row._asdict() for row in reservations]
+    past_reservations = [serialize_reservation(row) for row in reservations]
 
     return JSONResponse(content={"reservations": past_reservations}, status_code=200)
 


### PR DESCRIPTION
## Summary
- add a helper to serialize reservation rows returned by SQLAlchemy
- convert `in_time` and `out_time` timestamps to ISO date strings before returning active or past reservations

## Testing
- not run (database connection required)

------
https://chatgpt.com/codex/tasks/task_e_68ddb028d2cc832cb5f8da46ffee6ec1