### PR TITLE
Fix frontend API base URL handling

### DIFF
--- a/frontend/detalle.html
+++ b/frontend/detalle.html
@@ -44,6 +44,11 @@
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     const properties = {
       1: {
         title: 'Apartamento en El Poblado, Medellín',
@@ -129,7 +134,7 @@
 
     async function loadFeedback(propertyId) {
       try {
-        const response = await fetch(`/feedback/${propertyId}`);
+        const response = await fetch(`${API_BASE_URL}/feedback/${propertyId}`);
         const data = await response.json();
         const feedbackSection = document.getElementById('feedback-section');
 

--- a/frontend/feedback.html
+++ b/frontend/feedback.html
@@ -48,6 +48,11 @@
   </footer>
 
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     const params = new URLSearchParams(window.location.search);
     const bookingId = params.get('booking_id');
     const propertyId = params.get('property_id');
@@ -69,7 +74,7 @@
       }
 
       try {
-        const response = await fetch('/feedback', {
+        const response = await fetch(`${API_BASE_URL}/feedback`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,6 +110,11 @@ En ambos casos, FastAPI sabrá que debe buscar el archivo `style.css` dentro de 
   </footer>
 
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     function updateMenu() {
       const userId = localStorage.getItem('userId');
       const registerLink = document.getElementById('register-link');
@@ -147,7 +152,7 @@ En ambos casos, FastAPI sabrá que debe buscar el archivo `style.css` dentro de 
       const email = document.getElementById('register-email').value;
       const password = document.getElementById('register-password').value;
 
-      const response = await fetch('/register', {
+      const response = await fetch(`${API_BASE_URL}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email, password })
@@ -178,7 +183,7 @@ En ambos casos, FastAPI sabrá que debe buscar el archivo `style.css` dentro de 
         }
 //---------------------------------
 
-      const response = await fetch('/login', {
+      const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/frontend/mis-reservas.html
+++ b/frontend/mis-reservas.html
@@ -29,6 +29,11 @@
   </footer>
     
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     const properties = {
       1: { img: 'https://images.ctfassets.net/8lc7xdlkm4kt/33L5l2aTXdJAAEfw55n0Yh/7472faf6b498fdc11091fc65a5c69165/render-sobre-planos-saint-michel.jpg', coordinates: [6.2088, -75.5679] },
       2: { img: 'https://media-luna-hostel.cartagena-hotels.net/data/Photos/1080x700w/10392/1039228/1039228984/cartagena-media-luna-hostel-photo-1.JPEG', coordinates: [10.422385, -75.544984] },
@@ -46,7 +51,7 @@
 
     async function fetchActiveReservations(userId) {
       try {
-          const response = await fetch(`/active-reservations/${userId}`);
+          const response = await fetch(`${API_BASE_URL}/active-reservations/${userId}`);
           return await response.json();
       } catch (error) {
           console.error('Error en reservas activas:', error);
@@ -56,7 +61,7 @@
 
     async function fetchPastReservations(userId) {
       try {
-          const response = await fetch(`/past-reservations/${userId}`);
+          const response = await fetch(`${API_BASE_URL}/past-reservations/${userId}`);
           return await response.json();
       } catch (error) {
           console.error('Error en reservas pasadas:', error);

--- a/frontend/reserva-bef.html
+++ b/frontend/reserva-bef.html
@@ -42,12 +42,17 @@
 
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     const params = new URLSearchParams(window.location.search);
     const propertyId = params.get('id');
 
     async function getReservedDates(propertyId) {
       try {
-        const response = await fetch(`/reserved-dates/${propertyId}`);
+        const response = await fetch(`${API_BASE_URL}/reserved-dates/${propertyId}`);
         const data = await response.json();
         return data.reserved_dates; 
       } catch (error) {

--- a/frontend/reserva.html
+++ b/frontend/reserva.html
@@ -50,6 +50,11 @@
   </footer>
 
   <script>
+    const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+    const API_BASE_URL = isLocalhost && window.location.port !== '8000'
+      ? 'http://localhost:8000'
+      : window.location.origin;
+
     const reservationData = JSON.parse(localStorage.getItem('reservationData'));
 
     if (reservationData) {
@@ -75,7 +80,7 @@
       }
 
       try {
-          const response = await fetch(`/reserved-dates/${reservationData.property_id}`);
+          const response = await fetch(`${API_BASE_URL}/reserved-dates/${reservationData.property_id}`);
 
           if (!response.ok) {
               const errorText = await response.text();
@@ -99,7 +104,7 @@
               currentDate.setDate(currentDate.getDate() + 1);
           }
 
-          const reserveResponse = await fetch('/reserve', {
+          const reserveResponse = await fetch(`${API_BASE_URL}/reserve`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add a shared helper in each frontend page to detect the FastAPI backend URL
- update all fetch calls to use the computed backend base URL so requests work from static hosts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb2513060832caebf4ee0a170ea1b