### PR TITLE
Fix frontend Docker build by keeping nginx.conf in context

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,1 @@
-nginx.conf
+# Intentionally left blank so nginx.conf is included in the build context.


### PR DESCRIPTION
## Summary
- remove the `nginx.conf` entry from the frontend `.dockerignore` so the configuration is copied during the Docker build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5ec18cc8832c9eea85fc9026b9ce