### PR TITLE
Fix FastAPI static mount for frontend styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,8 +8,6 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <link rel="stylesheet" href="/estilos/styles.css">
   <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/2111/2111320.png" type="image/jpeg">
-  <link rel="stylesheet" href="/frontend/style.css"> 
-En ambos casos, FastAPI sabrá que debe buscar el archivo `style.css` dentro de la carpeta `frontend`.
 </head>
 
 <body class="bg-gray-100">

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from dotenv import load_dotenv
 from datetime import datetime, timedelta
+from pathlib import Path
 import os
 
 # Nuevas importaciones para PostgreSQL
@@ -15,8 +16,20 @@ from sqlalchemy.exc import SQLAlchemyError
 
 load_dotenv()
 app = FastAPI()
-app.mount("/estilos", StaticFiles(directory="frontend"), name="estilos")
-app.mount("/frontend", StaticFiles(directory="frontend"), name="frontend")
+
+BASE_DIR = Path(__file__).resolve().parent
+FRONTEND_DIR = BASE_DIR / "frontend"
+
+app.mount(
+    "/estilos",
+    StaticFiles(directory=str(FRONTEND_DIR / "estilos")),
+    name="estilos",
+)
+app.mount(
+    "/frontend",
+    StaticFiles(directory=str(FRONTEND_DIR)),
+    name="frontend",
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -66,7 +79,7 @@ def execute_query(query, params=None):
 
 @app.get("/")
 def home():
-    return FileResponse("frontend/index.html")
+    return FileResponse(FRONTEND_DIR / "index.html")
 
 @app.post("/register")
 async def register(user: RegisterRequest):


### PR DESCRIPTION
## Summary
- serve the frontend styles directory via FastAPI with an explicit static mount path
- load the index.html page from an absolute path and remove the stray stylesheet reference

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68de6367cd08832ca67077da1ca40ebc