### PR TITLE
Improve Docker compose build networking and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,32 +65,54 @@ Este proyecto es una plataforma web tipo Airbnb desarrollada con **HTML**, **CSS
 - Notificaciones por correo o SMS.
 
 
-## frontend con Docker (Nginx)
+## 🐳 Despliegue con Docker
 
 **Requisitos**
--Docker Desktop (Windows/Mac) o Docker Engine (Linux)
 
-1-Construir la imagen
+- Docker Desktop (Windows/Mac) o Docker Engine (Linux)
 
-Ubícate en la carpeta raíz del repo (donde existe la carpeta frontend/) y ejecuta:
+### Usando Docker Compose
+
+El archivo `docker-compose.yml` levanta los tres servicios necesarios (frontend, backend y base de datos). Para reducir problemas de DNS al descargar imágenes base (por ejemplo, `nginx:alpine` o `python:3.11-slim`), la definición de `build` usa `network: host`, lo que permite que BuildKit reutilice directamente la configuración de red del host.
+
+1. Construye y levanta los servicios:
+
+   ```bash
+   docker compose up --build
+   ```
+
+2. Abre el navegador en:
+
+   ```
+   http://localhost
+   ```
+
+> 💡 Si utilizas una red corporativa con proxy, asegúrate de que Docker tenga configuradas las variables `HTTP_PROXY`, `HTTPS_PROXY` y `NO_PROXY` en la sección *Resources → Proxies* para evitar errores del tipo `lookup registry-1.docker.io: no such host`.
+
+### Construcción manual del frontend
+
+Si prefieres construir únicamente el frontend estático:
+
+1. Ubícate en la carpeta raíz del repo (donde existe la carpeta `frontend/`) y ejecuta:
 
    ```bash
    cd frontend
    docker build -t airbnb-frontend .
    ```
 
-2-Ejecutar el contenedor
+2. Ejecuta el contenedor:
 
    ```bash
    docker run -d --name airbnb-frontend -p 8080:80 airbnb-frontend
    ```
 
-4. Abre el navegador en:
+3. Abre el navegador en:
+
    ```
    http://localhost:8080
    ```
 
-**Actualizar imagen tras cambios**
+4. Para actualizar la imagen tras cambios:
 
    ```bash
    docker rm -f airbnb-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '3.8'
-
 services:
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      network: host
     container_name: fastapi-backend
     restart: always
     ports:
@@ -10,14 +11,15 @@ services:
     environment:
       DATABASE_URL: postgresql://user_fastapi:mysecretpassword@db:5432/booking_app_db
     volumes:
-      - ./frontend:/app/frontend:ro  # Montar frontend como solo lectura
+      - ./frontend:/app/frontend:ro
     depends_on:
       - db
 
-  # ... el resto permanece igual
-
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      network: host
     container_name: nginx-frontend
     restart: always
     ports:
@@ -40,3 +42,4 @@ services:
 
 volumes:
   postgres_data:
+    name: booking-postgres-data


### PR DESCRIPTION
## Summary
- update docker-compose configuration to remove the deprecated version field, use explicit build blocks, and reuse the host network during image builds
- add a named volume for Postgres data and clean up comments
- document docker compose usage and provide DNS/proxy troubleshooting guidance for Docker builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de61925d38832ca15ed1034c5fc567