### PR TITLE
Improve API robustness and frontend routing

### DIFF
--- a/frontend/detalle.html
+++ b/frontend/detalle.html
@@ -43,6 +43,7 @@
   </footer>
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="/estilos/api.js"></script>
   <script>
     const properties = {
       1: {
@@ -129,7 +130,7 @@
 
     async function loadFeedback(propertyId) {
       try {
-        const response = await fetch(`/feedback/${propertyId}`);
+        const response = await apiFetch(`/feedback/${propertyId}`);
         const data = await response.json();
         const feedbackSection = document.getElementById('feedback-section');
 

--- a/frontend/estilos/api.js
+++ b/frontend/estilos/api.js
@@ -1,0 +1,65 @@
+(() => {
+  const normalizeBase = (value) => {
+    if (!value) {
+      return '';
+    }
+    return value.endsWith('/') ? value.slice(0, -1) : value;
+  };
+
+  const candidateBases = [];
+  const metaBase = document.querySelector('meta[name="api-base-url"]');
+  if (metaBase?.content) {
+    candidateBases.push(normalizeBase(metaBase.content));
+  }
+
+  candidateBases.push('/api');
+  candidateBases.push('');
+
+  let resolvedBase = null;
+
+  const fetchWithBase = async (base, path, options) => {
+    const cleanPath = path.startsWith('/') ? path : `/${path}`;
+    return fetch(`${base}${cleanPath}`, options);
+  };
+
+  const tryCandidates = async (path, options) => {
+    const basesToTry = resolvedBase !== null
+      ? [resolvedBase, ...candidateBases.filter((base) => base !== resolvedBase)]
+      : candidateBases;
+
+    let lastError;
+
+    for (const base of basesToTry) {
+      try {
+        const response = await fetchWithBase(base, path, options);
+
+        if (response.status === 404 && base !== '') {
+          // Puede que estemos golpeando la ruta equivocada (por ejemplo /api en local)
+          // Continuamos probando con la siguiente opción.
+          continue;
+        }
+
+        resolvedBase = base;
+        return response;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (lastError) {
+      throw lastError;
+    }
+
+    return fetchWithBase('', path, options);
+  };
+
+  window.apiFetch = async (path, options = {}) => {
+    return tryCandidates(path, options);
+  };
+
+  Object.defineProperty(window, 'API_BASE_URL', {
+    get() {
+      return resolvedBase ?? candidateBases[0] ?? '';
+    }
+  });
+})();

--- a/frontend/feedback.html
+++ b/frontend/feedback.html
@@ -47,6 +47,7 @@
     <p>&copy; 2025 AIRBNB JH-LS. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="/estilos/api.js"></script>
   <script>
     const params = new URLSearchParams(window.location.search);
     const bookingId = params.get('booking_id');
@@ -69,13 +70,12 @@
       }
 
       try {
-        const response = await fetch('/feedback', {
+        const response = await apiFetch('/feedback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            id_booking: bookingId,
             id_property: propertyId,
-            comments: comments,
+            comment: comments,
             rating: rating
           })
         });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -107,6 +107,7 @@
     <p>&copy; 2025 AIRBNB JH-LS. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="/estilos/api.js"></script>
   <script>
     function updateMenu() {
       const userId = localStorage.getItem('userId');
@@ -145,7 +146,7 @@
       const email = document.getElementById('register-email').value;
       const password = document.getElementById('register-password').value;
 
-      const response = await fetch('/register', {
+      const response = await apiFetch('/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email, password })
@@ -176,7 +177,7 @@
         }
 //---------------------------------
 
-      const response = await fetch('/login', {
+      const response = await apiFetch('/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/frontend/mis-reservas.html
+++ b/frontend/mis-reservas.html
@@ -28,6 +28,7 @@
     <p>&copy; 2025 AIRBNB JH-LS. Todos los derechos reservados.</p>
   </footer>
     
+  <script src="/estilos/api.js"></script>
   <script>
     const properties = {
       1: { img: 'https://images.ctfassets.net/8lc7xdlkm4kt/33L5l2aTXdJAAEfw55n0Yh/7472faf6b498fdc11091fc65a5c69165/render-sobre-planos-saint-michel.jpg', coordinates: [6.2088, -75.5679] },
@@ -46,7 +47,7 @@
 
     async function fetchActiveReservations(userId) {
       try {
-          const response = await fetch(`/active-reservations/${userId}`);
+          const response = await apiFetch(`/active-reservations/${userId}`);
           return await response.json();
       } catch (error) {
           console.error('Error en reservas activas:', error);
@@ -56,7 +57,7 @@
 
     async function fetchPastReservations(userId) {
       try {
-          const response = await fetch(`/past-reservations/${userId}`);
+          const response = await apiFetch(`/past-reservations/${userId}`);
           return await response.json();
       } catch (error) {
           console.error('Error en reservas pasadas:', error);

--- a/frontend/reserva-bef.html
+++ b/frontend/reserva-bef.html
@@ -41,13 +41,14 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script src="/estilos/api.js"></script>
   <script>
     const params = new URLSearchParams(window.location.search);
     const propertyId = params.get('id');
 
     async function getReservedDates(propertyId) {
       try {
-        const response = await fetch(`/reserved-dates/${propertyId}`);
+        const response = await apiFetch(`/reserved-dates/${propertyId}`);
         const data = await response.json();
         return data.reserved_dates; 
       } catch (error) {

--- a/frontend/reserva.html
+++ b/frontend/reserva.html
@@ -49,9 +49,8 @@
     <p>&copy; 2025 AIRBNB JH-LS. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="/estilos/api.js"></script>
   <script>
-    // Las peticiones van directamente al mismo origen (nginx hará el proxy)
-    const API_URL = '';
 
     const reservationData = JSON.parse(localStorage.getItem('reservationData'));
 
@@ -80,7 +79,7 @@
 
       try {
           // Usar API_URL para todas las peticiones
-          const response = await fetch(`${API_URL}/reserved-dates/${reservationData.property_id}`);
+          const response = await apiFetch(`/reserved-dates/${reservationData.property_id}`);
           const data = await response.json();
           const blockedDates = data.reserved_dates;
 
@@ -98,7 +97,7 @@
               currentDate.setDate(currentDate.getDate() + 1);
           }
 
-          const reserveResponse = await fetch(`${API_URL}/reserve`, {
+          const reserveResponse = await apiFetch('/reserve', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add automatic frontend path detection, SQLite fallback, and dual route registration so the API works with or without an /api prefix
- return the created user id, normalize reserved-date handling across databases, and harden reservation overlap checks
- introduce a reusable apiFetch helper and update each frontend page to call the backend consistently and with the correct payloads

## Testing
- python - <<'PY'
import os
from pathlib import Path
from sqlalchemy import text

test_db = Path('test_app.db')
if test_db.exists():
    test_db.unlink()

os.environ['DATABASE_URL'] = f'sqlite:///{test_db}'

from backend.main import app, engine
from fastapi.testclient import TestClient

with engine.begin() as conn:
    conn.execute(text('INSERT INTO "Property" (name, location, price, description, image_url) VALUES (:name, :location, :price, :description, :image_url)'), {
        'name': 'Propiedad de prueba',
        'location': 'Ciudad',
        'price': 100.0,
        'description': 'Descripción',
        'image_url': 'https://example.com/img.jpg'
    })

client = TestClient(app)

resp = client.post('/register', json={'name': 'Test User', 'email': 'test@example.com', 'password': 'secret'})
print('register', resp.status_code, resp.json())

resp_dup = client.post('/register', json={'name': 'Test User', 'email': 'test@example.com', 'password': 'secret'})
print('register-duplicate', resp_dup.status_code, resp_dup.json())

resp_login = client.post('/login', json={'email': 'test@example.com', 'password': 'secret'})
print('login', resp_login.status_code, resp_login.json())

resp_bad_login = client.post('/login', json={'email': 'test@example.com', 'password': 'wrong'})
print('login-bad', resp_bad_login.status_code, resp_bad_login.json())

resp_feedback = client.post('/feedback', json={'id_property': 1, 'comment': 'Muy bien', 'rating': 5})
print('feedback', resp_feedback.status_code, resp_feedback.json())

resp_feedback_get = client.get('/feedback/1')
print('feedback-get', resp_feedback_get.status_code, resp_feedback_get.json())

resp_reserve = client.post('/reserve', json={'property_id': 1, 'user_id': 1, 'in_time': '2030-01-01', 'out_time': '2030-01-05'})
print('reserve', resp_reserve.status_code, resp_reserve.json())

resp_reserve_overlap = client.post('/reserve', json={'property_id': 1, 'user_id': 1, 'in_time': '2030-01-03', 'out_time': '2030-01-04'})
print('reserve-overlap', resp_reserve_overlap.status_code, resp_reserve_overlap.json())

resp_reserved_dates = client.get('/reserved-dates/1')
print('reserved-dates', resp_reserved_dates.status_code, resp_reserved_dates.json())

resp_active = client.get('/active-reservations/1')
print('active', resp_active.status_code, resp_active.json())

resp_past = client.get('/past-reservations/1')
print('past', resp_past.status_code, resp_past.json())

resp_update = client.get('/update-reservations')
print('update', resp_update.status_code, resp_update.json())

client.close()
PY

------
https://chatgpt.com/codex/tasks/task_e_68de68e94f98832ca39a3f7189c03110