### PR TITLE
Prevent duplicate reservation feedback submissions

### DIFF
--- a/frontend/estilos/styles.css
+++ b/frontend/estilos/styles.css
@@ -271,6 +271,46 @@ body {
   background: #4338ca;
 }
 
+.feedback-btn {
+  background: #4f46e5;
+  color: white;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-top: 12px;
+  transition: background 0.2s ease-in-out;
+}
+
+.feedback-btn:hover {
+  background: #4338ca;
+}
+
+.feedback-badge {
+  margin-top: 16px;
+  font-weight: bold;
+  color: #16a34a;
+}
+
+.feedback-message {
+  font-size: 16px;
+  color: #4b5563;
+  margin-bottom: 16px;
+}
+
+.feedback-return {
+  display: inline-block;
+  padding: 10px 20px;
+  background: #4f46e5;
+  color: #fff;
+  border-radius: 8px;
+  text-decoration: none;
+}
+
+.feedback-return:hover {
+  background: #4338ca;
+}
+
 .cancel-btn {
   background: #ef4444;
   color: white;

--- a/frontend/feedback.html
+++ b/frontend/feedback.html
@@ -55,14 +55,39 @@
 
     if (!bookingId || !propertyId) {
       alert('Datos de reserva no encontrados.');
-      window.location.href = "index.html";
+      window.location.href = "mis-reservas.html";
     }
 
-    document.getElementById('feedback-details').addEventListener('submit', async (e) => {
+    const formContainer = document.getElementById('feedback-form');
+    const feedbackForm = document.getElementById('feedback-details');
+
+    async function ensureFeedbackAvailability() {
+      try {
+        const response = await apiFetch(`/feedback-status/${bookingId}`);
+        if (response.ok) {
+          const data = await response.json();
+          if (data.has_feedback) {
+            formContainer.innerHTML = `
+              <p class="feedback-message">Ya registraste un comentario para esta reserva.</p>
+              <a class="feedback-return" href="mis-reservas.html">Volver a Mis Reservas</a>
+            `;
+            return false;
+          }
+        }
+      } catch (error) {
+        console.error('Error al validar feedback:', error);
+        alert('No fue posible validar el estado del feedback. Intenta nuevamente.');
+        return false;
+      }
+
+      return true;
+    }
+
+    async function handleSubmit(e) {
       e.preventDefault();
 
       const comments = document.getElementById('comments').value;
-      const rating = parseInt(document.getElementById('rating').value);
+      const rating = parseInt(document.getElementById('rating').value, 10);
 
       if (!comments || !rating) {
         alert('Completa todos los campos obligatorios.');
@@ -74,7 +99,8 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            id_property: propertyId,
+            booking_id: parseInt(bookingId, 10),
+            id_property: parseInt(propertyId, 10),
             comment: comments,
             rating: rating
           })
@@ -82,15 +108,23 @@
 
         if (response.ok) {
           alert('¡Feedback enviado con éxito!');
-          window.location.href = "index.html";
+          window.location.href = "mis-reservas.html";
         } else {
-          alert('Error al enviar el feedback.');
+          const errorData = await response.json().catch(() => ({ message: 'Error al enviar el feedback.' }));
+          alert(errorData.message || 'Error al enviar el feedback.');
         }
       } catch (error) {
         console.error('Error:', error);
         alert('Error de conexión con el servidor.');
       }
-    });
+    }
+
+    (async () => {
+      const canSubmit = await ensureFeedbackAvailability();
+      if (canSubmit) {
+        feedbackForm.addEventListener('submit', handleSubmit);
+      }
+    })();
   </script>
 </body>
 </html>

--- a/frontend/mis-reservas.html
+++ b/frontend/mis-reservas.html
@@ -143,6 +143,8 @@
       card.classList.add('card');
 
       const canCancel = !isPast && canCancelReservation(reservation.in_time);
+      const hasFeedback = Boolean(Number(reservation.has_feedback ?? 0));
+      const showFeedbackButton = isPast && !hasFeedback;
 
       card.innerHTML = `
           <img src="${property.img}" alt="${reservation.property_name}">
@@ -162,21 +164,25 @@
                   Cancelar Reserva
               </button>`
               : ''}
-          ${isPast ?
-              `<button class="directions-btn"
+          ${showFeedbackButton ?
+              `<button class="feedback-btn"
                       data-booking-id="${reservation.id}"
                       data-property-id="${reservation.property_id}">
                   Dejar Feedback
-              </button>` 
+              </button>`
+              : ''}
+          ${!showFeedbackButton && hasFeedback ?
+              `<p class="feedback-badge">Feedback enviado</p>`
               : ''}
       `;
 
       document.getElementById('reservations-container').appendChild(card);
 
-      if (isPast) {
-          card.querySelector('.directions-btn').addEventListener('click', (e) => {
-              const bookingId = e.target.dataset.bookingId;
-              const propertyId = e.target.dataset.propertyId;
+      const feedbackButton = card.querySelector('.feedback-btn');
+      if (feedbackButton) {
+          feedbackButton.addEventListener('click', (e) => {
+              const bookingId = e.currentTarget.dataset.bookingId;
+              const propertyId = e.currentTarget.dataset.propertyId;
               window.location.href = `feedback.html?booking_id=${bookingId}&property_id=${propertyId}`;
           });
       }


### PR DESCRIPTION
## Summary
- ensure feedback records are tied to bookings and expose a status endpoint for clients
- hide the feedback button on past reservations after a comment exists and show a confirmation badge
- block repeat submissions from the feedback form and provide a return link when feedback already exists

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09a209938832cbabb019ac54192ce