### PR TITLE
Fix Prometheus instrumentation startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -747,9 +747,11 @@ async def get_feedback(property_id: int):
     return JSONResponse(content={"feedback": feedback_list}, status_code=200)
 
 
+configure_metrics(app)
+
+
 @app.on_event("startup")
 async def on_startup() -> None:
-    configure_metrics(app)
     update_database_health_metric()
     app.state.db_monitor_task = asyncio.create_task(monitor_database_health())
 


### PR DESCRIPTION
## Summary
- configure the Prometheus instrumentator before FastAPI startup so middleware can be registered
- keep the database health background task during startup without re-configuring metrics

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'main')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ca36a898832c999bb180c6267dc5)